### PR TITLE
Change file descriptor to be blocking.

### DIFF
--- a/ftrace/file.go
+++ b/ftrace/file.go
@@ -73,7 +73,7 @@ func (localFileProvider) OpenFtrace(filename string) (io.ReadCloser, error) {
 		return nil, BadFtraceFileName
 	}
 
-	return os.OpenFile(path.Join(ftracePath, filename), os.O_RDONLY, os.ModeNamedPipe)
+	return os.Open(path.Join(ftracePath, filename))
 }
 
 // recordingFileProvider

--- a/ftrace/file.go
+++ b/ftrace/file.go
@@ -73,7 +73,7 @@ func (localFileProvider) OpenFtrace(filename string) (io.ReadCloser, error) {
 		return nil, BadFtraceFileName
 	}
 
-	return os.Open(path.Join(ftracePath, filename))
+	return os.OpenFile(path.Join(ftracePath, filename), os.O_RDONLY, os.ModeNamedPipe)
 }
 
 // recordingFileProvider

--- a/ftrace/raw.go
+++ b/ftrace/raw.go
@@ -41,6 +41,7 @@ func getRawFtraceChan(fp FileProvider, cpu int, doneCh <-chan bool) (<-chan []by
 
 		for {
 			var buf = make([]byte, syscall.Getpagesize())
+			syscall.SetNonblock(int(f.(*os.File).Fd()), false)
 			n, err := f.Read(buf)
 			if e, ok := err.(*os.PathError); ok && e.Err == syscall.EINTR {
 				continue
@@ -52,7 +53,6 @@ func getRawFtraceChan(fp FileProvider, cpu int, doneCh <-chan bool) (<-chan []by
 					if _, ok := fp.(*testFileProvider); ok {
 						break
 					}
-
 				} else {
 					fmt.Println(err, "ignoring")
 				}

--- a/ftrace/raw.go
+++ b/ftrace/raw.go
@@ -53,6 +53,7 @@ func getRawFtraceChan(fp FileProvider, cpu int, doneCh <-chan bool) (<-chan []by
 					if _, ok := fp.(*testFileProvider); ok {
 						break
 					}
+
 				} else {
 					fmt.Println(err, "ignoring")
 				}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/atsu/traceout


### PR DESCRIPTION
This appears to be changed via the go runtime, as we need to set the file descriptor type prior to each read call. 

`gather` seems to function the same in go1.8 or go 1.11. 